### PR TITLE
replacing a no longer available repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,5 +120,11 @@
     ],
     "extra": {
         "public-dir": "public"
-    }    
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mshanken/utilphp"
+        }
+    ]
 }


### PR DESCRIPTION
To replace a repo that no longer exists

See: https://github.com/bolt/bolt/blob/master/.github/CONTRIBUTING.md

Fixes: CI?PHPUnit test from github


